### PR TITLE
Nightly fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 
 extern crate alloc;
 
-#[cfg(test)] mod tests;
+#[cfg(test)]
+mod tests;
 
 use alloc::raw_vec::RawVec;
 use std::{fmt, mem, ops, ptr, slice};
@@ -48,9 +49,7 @@ impl<T: Default> DefaultVec<T> {
     /// Get a reference to the value in position `idx`, panicking if the index is out of bounds.
     pub fn get(&self, idx: usize) -> &T {
         assert!(idx < self.capacity());
-        unsafe {
-            &*self.raw.ptr().add(idx)
-        }
+        unsafe { &*self.raw.ptr().add(idx) }
     }
 
     /// Get a reference to the value in position `idx`, resizing if the index is out of bounds.
@@ -58,9 +57,7 @@ impl<T: Default> DefaultVec<T> {
         if idx >= self.capacity() {
             self.resize(idx + 1);
         }
-        unsafe {
-            &mut *self.raw.ptr().add(idx)
-        }
+        unsafe { &mut *self.raw.ptr().add(idx) }
     }
 
     /// Inserts a value into the vector, returning the old value.
@@ -99,17 +96,13 @@ impl<T: Default> ops::Deref for DefaultVec<T> {
     type Target = [T];
 
     fn deref(&self) -> &Self::Target {
-        unsafe {
-            slice::from_raw_parts(self.raw.ptr(), self.raw.capacity())
-        }
+        unsafe { slice::from_raw_parts(self.raw.ptr(), self.raw.capacity()) }
     }
 }
 
 impl<T: Default> ops::DerefMut for DefaultVec<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe {
-            slice::from_raw_parts_mut(self.raw.ptr(), self.raw.capacity())
-        }
+        unsafe { slice::from_raw_parts_mut(self.raw.ptr(), self.raw.capacity()) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ impl<T: Default> DefaultVec<T> {
         let raw: RawVec<T> = RawVec::with_capacity(cap);
         for i in 0..raw.capacity() {
             unsafe {
-                ptr::write(raw.ptr().offset(i as isize), T::default());
+                ptr::write(raw.ptr().add(i), T::default());
             }
         }
         DefaultVec { raw }
@@ -40,7 +40,7 @@ impl<T: Default> DefaultVec<T> {
         self.raw.reserve(old_cap, new_cap.saturating_sub(old_cap));
         for i in old_cap..self.capacity() {
             unsafe {
-                ptr::write(self.raw.ptr().offset(i as isize), T::default());
+                ptr::write(self.raw.ptr().add(i), T::default());
             }
         }
     }
@@ -49,7 +49,7 @@ impl<T: Default> DefaultVec<T> {
     pub fn get(&self, idx: usize) -> &T {
         assert!(idx < self.capacity());
         unsafe {
-            &*self.raw.ptr().offset(idx as isize)
+            &*self.raw.ptr().add(idx)
         }
     }
 
@@ -59,7 +59,7 @@ impl<T: Default> DefaultVec<T> {
             self.resize(idx + 1);
         }
         unsafe {
-            &mut *self.raw.ptr().offset(idx as isize)
+            &mut *self.raw.ptr().add(idx)
         }
     }
 
@@ -71,7 +71,7 @@ impl<T: Default> DefaultVec<T> {
     /// Removes a value from the vector.
     pub fn remove(&mut self, idx: usize) -> T {
         if idx < self.capacity() {
-            mem::replace(self.get_mut(idx), T::default())
+            std::mem::take(self.get_mut(idx))
         } else {
             T::default()
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(alloc)]
+#![feature(raw_vec_internals)]
 
 extern crate alloc;
 
@@ -20,8 +20,8 @@ impl<T: Default> DefaultVec<T> {
 
     /// Creates an empty vector with capacity for `cap` values.
     pub fn with_capacity(cap: usize) -> Self {
-        let raw = RawVec::with_capacity(cap);
-        for i in 0..raw.cap() {
+        let raw: RawVec<T> = RawVec::with_capacity(cap);
+        for i in 0..raw.capacity() {
             unsafe {
                 ptr::write(raw.ptr().offset(i as isize), T::default());
             }
@@ -31,7 +31,7 @@ impl<T: Default> DefaultVec<T> {
 
     /// Returns the total number of values the vector stores.
     pub fn capacity(&self) -> usize {
-        self.raw.cap()
+        self.raw.capacity()
     }
 
     /// Resizes the vector to contain at least `new_cap` values.
@@ -100,7 +100,7 @@ impl<T: Default> ops::Deref for DefaultVec<T> {
 
     fn deref(&self) -> &Self::Target {
         unsafe {
-            slice::from_raw_parts(self.raw.ptr(), self.raw.cap())
+            slice::from_raw_parts(self.raw.ptr(), self.raw.capacity())
         }
     }
 }
@@ -108,7 +108,7 @@ impl<T: Default> ops::Deref for DefaultVec<T> {
 impl<T: Default> ops::DerefMut for DefaultVec<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
-            slice::from_raw_parts_mut(self.raw.ptr(), self.raw.cap())
+            slice::from_raw_parts_mut(self.raw.ptr(), self.raw.capacity())
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,7 @@
 use super::DefaultVec;
 
 #[test]
-fn test() {
+fn test_basic_usage() {
     let mut vec = DefaultVec::new();
 
     assert_eq!(*vec.get_mut(0), 0);
@@ -13,14 +13,36 @@ fn test() {
     assert_eq!(vec.insert(1, 2), 0);
     assert_eq!(vec.insert(2, -6), 0);
     assert_eq!(vec.insert(3, 12), 0);
+    assert_eq!(vec.insert(10, 66), 0);
 
     assert_eq!(*vec.get(0), 5);
     assert_eq!(*vec.get(1), 2);
     assert_eq!(*vec.get(2), -6);
     assert_eq!(*vec.get(3), 12);
+    assert_eq!(*vec.get(4), 0);
+    assert_eq!(*vec.get(9), 0);
+    assert_eq!(*vec.get(10), 66);
 
     assert_eq!(vec.remove(0), 5);
     assert_eq!(vec.remove(1), 2);
     assert_eq!(vec.remove(2), -6);
     assert_eq!(vec.remove(3), 12);
+
+    assert_eq!(*vec.get_mut(0), 0);
+    assert_eq!(*vec.get_mut(1), 0);
+    assert_eq!(*vec.get_mut(2), 0);
+    assert_eq!(*vec.get_mut(3), 0);
+}
+
+#[test]
+#[should_panic]
+fn test_panic() {
+    let mut vec = DefaultVec::new();
+
+    assert_eq!(vec.insert(0, 5), 0);
+    assert_eq!(vec.insert(1, 2), 0);
+    assert_eq!(vec.insert(2, -6), 0);
+    assert_eq!(vec.insert(3, 12), 0);
+
+    assert_eq!(*vec.get(4), 0);
 }


### PR DESCRIPTION
I've been looking for a data structure like this for Rust!

This PR makes default-vec compile on today's nightly.

I also expanded the tests a little to cover more behaviours and fixed some lints.

If you want to use `rustfmt` I could push another commit.